### PR TITLE
Remove splash screen on GLES builds

### DIFF
--- a/Code/Libraries/Core/src/display.cpp
+++ b/Code/Libraries/Core/src/display.cpp
@@ -173,7 +173,7 @@ void Display::UpdateDisplay()
 	GetCurrentDisplayMode( CurrentWidth, CurrentHeight, CurrentRefreshRate );
 
 	STATICHASH( DisplayDepth );
-#ifdef USE_GLES
+#ifdef HAVE_GLES
 	const uint DisplayDepth = ConfigManager::GetInt( sDisplayDepth, 16 );
 #else
 	const uint DisplayDepth = ConfigManager::GetInt( sDisplayDepth, 32 );

--- a/Code/Libraries/Framework/src/framework3d.cpp
+++ b/Code/Libraries/Framework/src/framework3d.cpp
@@ -59,7 +59,7 @@ Framework3D::Framework3D()
 :	m_EventManager( NULL )
 ,	m_Display( NULL )
 ,	m_Window( NULL )
-#ifndef PANDORA
+#ifndef HAVE_GLES
 ,	m_SplashWindow( NULL )
 #endif
 ,	m_Keyboard( NULL )
@@ -203,7 +203,7 @@ void Framework3D::Main()
 
 	STATICHASH( UseFixedFrameTime );
 	m_UseFixedFrameTime	= ConfigManager::GetBool( sUseFixedFrameTime, true, sFramework );
-#ifdef HAVE_GLES0
+#ifdef HAVE_GLES
 	m_UseFixedFrameTime = false;    // GLES hardware are less powerful than Desktop
 #endif
 
@@ -244,7 +244,9 @@ void Framework3D::Main()
 	GetInitialWindowSize( WindowWidth, WindowHeight );
 	GetInitialWindowTitle( WindowTitle );
 
+#ifndef HAVE_GLES
 	CreateSplashWindow( WindowIcon, WindowTitle.CStr() );
+#endif
 
 	m_Window = new Window;
 
@@ -333,7 +335,7 @@ void Framework3D::Main()
 
 	if( ShowWindowASAP() )
 	{
-#ifndef PANDORA
+#ifndef HAVE_GLES
 		SafeDelete( m_SplashWindow );
 #endif
 #if BUILD_WINDOWS_NO_SDL
@@ -359,13 +361,13 @@ void Framework3D::Main()
 	m_IsInitializing = false;
 }
 
+#ifndef HAVE_GLES
 void Framework3D::CreateSplashWindow( const uint WindowIcon, const char* const Title )
 {
 	XTRACE_FUNCTION;
 
 	STATICHASH( Framework );
 	STATICHASH( SplashImage );
-#ifndef PANDORA
 	const char* const	pSplashImage		= ConfigManager::GetString( sSplashImage, NULL, sFramework );
 	if( !pSplashImage )
 	{
@@ -412,8 +414,8 @@ void Framework3D::CreateSplashWindow( const uint WindowIcon, const char* const T
     {
     }
 #endif
-#endif
 }
+#endif
 
 /*virtual*/ void Framework3D::ShutDown()
 {
@@ -437,7 +439,7 @@ void Framework3D::CreateSplashWindow( const uint WindowIcon, const char* const T
 #endif
 
 	SafeDelete( m_Display );
-#ifndef PANDORA
+#ifndef HAVE_GLES
 	SafeDelete( m_SplashWindow );
 #endif
 	SafeDelete( m_Clock );

--- a/Code/Libraries/Framework/src/framework3d.h
+++ b/Code/Libraries/Framework/src/framework3d.h
@@ -101,7 +101,9 @@ protected:
 #endif
 
 	// Initialization hooks for framework implementations
+#ifndef HAVE_GLES
 	virtual void	CreateSplashWindow( const uint WindowIcon, const char* const Title );
+#endif
 	virtual void	GetInitialWindowSize( uint& WindowWidth, uint& WindowHeight );
 	virtual void	GetInitialWindowTitle( SimpleString& WindowTitle );
 	virtual void	GetInitialWindowIcon( uint& WindowIcon );
@@ -126,7 +128,7 @@ protected:
 	WBEventManager*			m_EventManager;	// Event manager for framework only, not for game.
 	Display*				m_Display;
 	Window*					m_Window;
-#ifndef PANDORA
+#ifndef HAVE_GLES
 	Window*					m_SplashWindow;
 #endif
 	Keyboard*				m_Keyboard;

--- a/Code/Projects/Eld/src/eldframework.cpp
+++ b/Code/Projects/Eld/src/eldframework.cpp
@@ -599,7 +599,7 @@ ENotificationPosition GetSteamNoticePos( const HashedString& SteamNoticePosName 
 	}
 
 	// All done, show the window finally.
-#ifndef PANDORA
+#ifndef HAVE_GLES
 	SafeDelete( m_SplashWindow );
 #endif
 #if BUILD_WINDOWS_NO_SDL


### PR DESCRIPTION
This PR does what was requested on #10 (remove splash screen on GLES builds) and fixes some wrong `#ifdef`s (`USE_GLES` instead of `HAVE_GLES`).